### PR TITLE
unstyled ssr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ If you are creating an open source application under a license compatible with t
 
 This wrapper creates a ```<ReactFullpage />``` component. It exposes a render-prop API so markup can remain the same across fullpage.js libraries. The render prop accepts 1 parameter in its callback which contains the component's react properties state, context, etc.
 
+## Server Side Rendering
+
+SSR is supported however the rendered html will not be styled, this is because window must be present in order to properly set height + width of slides. So long as you rehydrate your fullpage component in the browser environment, regular styles will be applied.
+
 ## Examples
 
 In-depth examples can be found [here](https://github.com/alvarotrigo/react-fullpage/tree/master/example)

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactFullpage from '@fullpage/react-fullpage';
+import ReactFullpage from '../../components/ReactFullpage';
 import 'fullpage.js/vendors/scrolloverflow'; // Optional. When using scrollOverflow:true
 
 const fullpageOptions = {


### PR DESCRIPTION
This will catch errors during SSR scenarios and return an empty div instead. If we want full SSR support we'll need to provide window/document and any other browser based globals as arguments to `fullpage.js` so the functionality can be stubbed