### PR TITLE
Missing classes

### DIFF
--- a/components/ReactFullpage/index.js
+++ b/components/ReactFullpage/index.js
@@ -223,7 +223,7 @@ class ReactFullpage extends React.Component {
       <div id="fullpage">
         {this.state.initialized
           ? this.props.render(this)
-          : <div className="section" />
+          : <div className="section fp-section active" />
         }
       </div>
     );


### PR DESCRIPTION
When we initialize the dummy section we also need these in order to avoid issues like

https://github.com/alvarotrigo/react-fullpage/issues/27
https://github.com/alvarotrigo/react-fullpage/issues/31