### PR TITLE
Plugin extensions hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,17 @@ Fullpage.js Extension Example:
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
-import 'fullpage.js/vendors/scrolloverflow'; // Optional. When using the fullPage.js option scrollOverflow:true
-
-// Optional. When using add-on fullpage extensions
-//import './fullpage.scrollHorizontally.min'
-
 import ReactFullpage from '@fullpage/react-fullpage';
+
+// NOTE: if using fullpage extensions/plugins put them here and pass it as props
+const pluginWrapper = () => {
+  require('fullpage.js/vendors/scrolloverflow');
+  require('./statics/fullpage.scrollHorizontally.min');
+};
 
 const Fullpage = () => (
   <ReactFullpage
+    pluginWrapper
     render={({ state, fullpageApi }) => {
       return (
         <ReactFullpage.Wrapper>

--- a/components/Logger/index.js
+++ b/components/Logger/index.js
@@ -1,0 +1,5 @@
+export default (debug, compName) => {
+  return debug
+    ? (...args) => console.log(...[`<${compName}/> Debug Log: `, ...args])
+    : () => {};
+};

--- a/components/ReactFullpage/index.js
+++ b/components/ReactFullpage/index.js
@@ -1,8 +1,11 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable react/prop-types */
 import React from 'react';
-import Fullpage from 'fullpage.js/dist/fullpage.extensions.min';
 import fullpageStyles from 'fullpage.js/dist/fullpage.min.css'; // eslint-disable-line no-unused-vars
+
+import Logger from '../Logger';
+
+let Fullpage;
 
 const isFunc = val => typeof val === 'function';
 const fullpageCallbacks = [
@@ -19,11 +22,22 @@ const fullpageCallbacks = [
 class ReactFullpage extends React.Component {
   constructor(props) {
     super(props);
-    const { render } = this.props;
+    const { render, pluginWrapper } = this.props;
 
     if (!isFunc(render)) {
       throw new Error('must provide render prop to <ReactFullpage />');
     }
+
+    this.log = Logger(this.props.debug, 'ReactFullpage');
+    this.log('Building component');
+
+    if (pluginWrapper) {
+      this.log('Calling plugin wrapper');
+      pluginWrapper();
+    }
+
+    this.log('Requiring fullpage.js');
+    Fullpage = require('fullpage.js/dist/fullpage.extensions.min');
 
     this.state = {
       initialized: false,
@@ -44,13 +58,9 @@ class ReactFullpage extends React.Component {
     const newSlideCount = this.getSlideCount();
     const { sectionCount, slideCount } = this.state;
 
-    /* TODO: add a list of fullpage.js specific props to subscribe too
-      similar to how callbacks are handled)
-    */
-
+    // NOTE: if fullpage props have changed we need to rebuild
     if (this.props.sectionsColor !== prevProps.sectionsColor) {
-      console.log('rebuilding due to a change in fullpage.js props');
-      // NOTE: if fullpage props have changed we need to rebuild
+      this.log('rebuilding due to a change in fullpage.js props');
       this.destroy();
       this.init(this.buildOptions());
       return;
@@ -60,8 +70,8 @@ class ReactFullpage extends React.Component {
       return;
     }
 
-    console.log('rebuilding due to a change in fullpage.js sections/slides');
-    // NOTE: if sections have changed we need to rebuild
+    // NOTE: if sections/slides have changed we need to rebuild
+    this.log('rebuilding due to a change in fullpage.js sections/slides');
     this.destroy();
     this.init(this.buildOptions());
   }
@@ -81,20 +91,20 @@ class ReactFullpage extends React.Component {
   }
 
   init(opts) {
-        new Fullpage('#fullpage', opts) // eslint-disable-line
+    this.log('Reinitializing fullpage with options', opts);
+    new Fullpage('#fullpage', opts) // eslint-disable-line
     this.fullpageApi = window.fullpage_api;
     this.fpUtils = window.fp_utils;
     this.fpEasings = window.fp_easings;
   }
 
   destroy() {
-    // NOTE: need to check for init to support SSR
-    if (typeof window !== 'undefined') {
-      this.fullpageApi.destroy('all');
-    }
+    this.log('Destroying fullpage instance');
+    this.fullpageApi.destroy('all');
   }
 
   markInitialized() {
+    this.log('Marking initialized');
     this.setState({
       initialized: true,
       sectionCount: this.getSectionCount(),
@@ -115,13 +125,17 @@ class ReactFullpage extends React.Component {
     }, {});
 
     // NOTE: override passed in callbacks w/  wrapped listeners
-    return {
+    const options = {
       ...this.props,
       ...listeners,
     };
+
+    this.log('Building fullpage.js options: ', options);
+    return options;
   }
 
   update(lastEvent, ...args) {
+    this.log('Event trigger: ', lastEvent);
     let state = {
       ...this.state,
       sectionCount: this.getSectionCount(),
@@ -185,11 +199,14 @@ class ReactFullpage extends React.Component {
     }
 
     const returned = this.props[lastEvent](...args);
+    this.log('Called callback: Returning => ', returned);
+    this.log('Updating State => ', state);
     this.setState(state);
     return returned;
   }
 
   render() {
+    this.log('<== Rendering ==>');
     return <div id="fullpage">{this.props.render(this)}</div>;
   }
 }

--- a/components/ReactFullpageShell/index.js
+++ b/components/ReactFullpageShell/index.js
@@ -3,11 +3,15 @@
 
 import React from 'react';
 
+import Logger from '../Logger';
+
 // NOTE: SSR support
 class ReactFullpageShell extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
+    this.log = Logger(this.props.debug, 'ReactFullpageShell');
+    this.log('Building component');
   }
 
   render() {

--- a/components/index.js
+++ b/components/index.js
@@ -1,10 +1,12 @@
 /* eslint-disable */
 import Wrapper from './Wrapper'
 
+const windowExists = () => typeof window !== 'undefined';
+
 export default (() => {
     let exported
 
-    if (typeof window !== 'undefined') {
+    if (windowExists()) {
         exported = require('./ReactFullpage').default
     } else {
         // NOTE: SSR support

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -2,7 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactFullpage from '../../components';
 
-// import 'fullpage.js/vendors/scrolloverflow'; // Optional. When using scrollOverflow:true
+// NOTE: if using fullpage extensions/plugins put them here and pass it as props
+const pluginWrapper = () => {
+  /**
+   * require('fullpage.js/vendors/scrolloverflow'); // Optional. When using scrollOverflow:true
+   */
+};
 
 const originalColors = ['#282c34', '#ff5f45', '#0798ec'];
 
@@ -97,20 +102,21 @@ class App extends React.Component {
       <div className="App">
         <Menu />
         <ReactFullpage
+          debug /* Debug logging */
+          scrollOverflow
           navigation
           onLeave={this.onLeave.bind(this)}
           sectionsColor={this.state.sectionsColor}
-          render={comp =>
-            console.log('render prop change') || (
-              <ReactFullpage.Wrapper>
-                {fullpages.map(({ text }) => (
-                  <div key={text} className="section">
-                    <h1>{text}</h1>
-                  </div>
-                ))}
-              </ReactFullpage.Wrapper>
-            )
-          }
+          pluginWrapper={pluginWrapper}
+          render={comp => (
+            <ReactFullpage.Wrapper>
+              {fullpages.map(({ text }) => (
+                <div key={text} className="section">
+                  <h1>{text}</h1>
+                </div>
+              ))}
+            </ReactFullpage.Wrapper>
+          )}
         />
       </div>
     );


### PR DESCRIPTION
Providing a hook so that extensions are only loaded in the real component vs the shell that is loaded during ssr. Also added a debug logger. Note that scroll overflow extension is still causing maximum call stack error until https://github.com/alvarotrigo/react-fullpage/issues/38 is resolved

Should fix https://github.com/alvarotrigo/react-fullpage/issues/71