### PR TITLE
Fix importing vendors on ssr

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ import ReactFullpage from '@fullpage/react-fullpage';
 
 // NOTE: if using fullpage extensions/plugins put them here and pass it as props
 const pluginWrapper = () => {
-  require('fullpage.js/vendors/scrolloverflow');
   require('./statics/fullpage.scrollHorizontally.min');
 };
 
@@ -161,7 +160,7 @@ const Fullpage = () => (
 ReactDOM.render(<Fullpage />, document.getElementById('react-root'));
 ```
 
-Notice that when using the option `scrollOverflow:true` or any [fullPage.js extension](https://alvarotrigo.com/fullPage/extensions/) you'll have to include the file for those features before the `react-fullpage` component.
+Notice that when using any [fullPage.js extension](https://alvarotrigo.com/fullPage/extensions/) you'll pass the `pluginWrapper` function prop to include the file for those features before the `react-fullpage` component mounted.  
 
 ## State
 

--- a/components/ReactFullpage/index.js
+++ b/components/ReactFullpage/index.js
@@ -4,7 +4,12 @@ import React from 'react';
 import fullpageStyles from 'fullpage.js/dist/fullpage.min.css'; // eslint-disable-line no-unused-vars
 
 import Logger from '../Logger';
-import { MAIN_SELECTOR, ID_SELECTOR, DEFAULT_SECTION, DEFAULT_SLIDE } from '../selectors';
+import {
+  MAIN_SELECTOR,
+  ID_SELECTOR,
+  DEFAULT_SECTION,
+  DEFAULT_SLIDE,
+} from '../selectors';
 
 let Fullpage;
 
@@ -31,6 +36,9 @@ class ReactFullpage extends React.Component {
 
     this.log = Logger(this.props.debug, 'ReactFullpage');
     this.log('Building component');
+
+    this.log('Importing vendor files');
+    this.importVendors();
 
     if (pluginWrapper) {
       this.log('Calling plugin wrapper');
@@ -65,8 +73,9 @@ class ReactFullpage extends React.Component {
 
     //comparing sectionColors array option
     var areSameSectionColors = true;
-    this.props.sectionsColor.forEach(function(item, index){
-      areSameSectionColors = item === prevProps.sectionsColor[index] && areSameSectionColors;     
+    this.props.sectionsColor.forEach(function(item, index) {
+      areSameSectionColors =
+        item === prevProps.sectionsColor[index] && areSameSectionColors;
     });
 
     // NOTE: if fullpage props have changed we need to rebuild
@@ -101,6 +110,16 @@ class ReactFullpage extends React.Component {
     const { slideSelector = DEFAULT_SLIDE } = this.props;
     const { length } = document.querySelectorAll(slideSelector);
     return length;
+  }
+
+  importVendors() {
+    const { scrollOverflow, easing } = this.props;
+    if (scrollOverflow) {
+      require('fullpage.js/vendors/scrolloverflow.min');
+    }
+    if (easing) {
+      require('fullpage.js/vendors/easings.min');
+    }
   }
 
   init(opts) {


### PR DESCRIPTION
Resolve #130 

* Import vendor files when related options provided (`scrollOverflow`, `easing`)
* Update README to clarify using `pluginWrapper` prop in order to prevent similar issues.

And also I will open a pull request to the [Next.js example](https://github.com/cmswalker/react-fullpage-next-example) using `pluginWrapper`.