### PR TITLE
- Fixed: Update broken in-depth `examples` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can find a [Gatsby](https://github.com/alvarotrigo/react-fullpage/tree/maste
 
 ## Examples
 
-In-depth examples can be found [here](https://github.com/alvarotrigo/react-fullpage/tree/master/example)
+In-depth examples can be found [here](https://github.com/alvarotrigo/react-fullpage/tree/master/examples). You can start with the [React Example](https://github.com/alvarotrigo/react-fullpage/tree/master/examples/react).
 
 Quickstart Example:
 

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -16,14 +16,14 @@ Now you'll be able to access the example at: http://localhost:8080/
 
 ## Building the example
 
-In order generate the bundle dist files run the following command from the root folder:
+In order to generate the bundle dist files run the following command from the root folder:
 
 ``` bash
 # install dependencies
 npm install
 
-# serve the example
+# build the example
 npm run build:dev
 ```
 
-Build files will be generated in the `/example/dist/` folder.
+Build files will be generated in the `/examples/react/dist/` folder.


### PR DESCRIPTION
Resolves: #150

- Update `examples` path link
- Add `React Example` path link. So that user can start with this example, in case more examples will be added in future.
- Update Readme of react example with some corrections