### PR TITLE
I think ReactFullpage needs to be added className props

### DIFF
--- a/components/ReactFullpage/index.js
+++ b/components/ReactFullpage/index.js
@@ -243,7 +243,7 @@ class ReactFullpage extends React.Component {
 
   render() {
     this.log('<== Rendering ==>');
-    return <div id={MAIN_SELECTOR}>{this.props.render(this)}</div>;
+    return <div id={MAIN_SELECTOR} className={this.props.className}>{this.props.render(this)}</div>;
   }
 }
 


### PR DESCRIPTION
My project has multiple pages using 'fullpage.js',
I wanted to branch CSS styling via distinguishing className, but there was no way to set className.