### PR TITLE
Fixing common js builds after webpack upgrade

### DIFF
--- a/webpack.config.build.js
+++ b/webpack.config.build.js
@@ -28,7 +28,6 @@ module.exports = [
     output: {
       path: path.join(__dirname, 'dist'),
       filename: 'react-fullpage.js',
-      library: 'ReactFullpage',
       libraryTarget: 'commonjs2',
     },
   }),


### PR DESCRIPTION
Issue:
Production commonjs builds were not working.

Solution:
The library field was creating a named export, due to which things were not behaving as expected.
reference:
- https://github.com/webpack/webpack/issues/11800#issue-728535307
- https://webpack.js.org/configuration/output/#module-definition-systems